### PR TITLE
Update AutoTune_Example.ino

### DIFF
--- a/PID_AutoTune_v0/Examples/AutoTune_Example/AutoTune_Example.ino
+++ b/PID_AutoTune_v0/Examples/AutoTune_Example/AutoTune_Example.ino
@@ -71,11 +71,11 @@ void setup()
   // PI tunings perform well for delay dominated processes
   // for lag-dominated processes PID tunings are better because
   // the derivative term allows higher integral gain
-  //aTune.SetControlType(AMIGOF_PI);
-  //aTune.SetControlType(ZIEGLER_NICHOLS_PI);
-  //aTune.SetControlType(TYREUS_LUYBEN_PI);
+  //aTune.SetControlType(PID_ATune::AMIGOF_PI);
+  //aTune.SetControlType(PID_ATune::ZIEGLER_NICHOLS_PI);
+  //aTune.SetControlType(PID_ATune::TYREUS_LUYBEN_PI);
   aTune.SetControlType(PID_ATune::ZIEGLER_NICHOLS_PID);
-  //aTune.SetControlType(NO_OVERSHOOT_PID);
+  //aTune.SetControlType(PID_ATune::NO_OVERSHOOT_PID);
 
   // set up simulation parameters
 #if defined (SIMULATION_MODEL_LAG_DOMINATED)


### PR DESCRIPTION
Added missing "PID_ATune::" to get rid of compile error "was not declared in this scope" on Arduino v 1.0.5
